### PR TITLE
Add static build for Tomato firmware based router

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,10 @@ endif
 
 LDFLAGS += $(LIBS)
 
+ifdef STATIC
+LDFLAGS += -Wl,-static -static -static-libgcc -s
+endif
+
 XSOCKSD=$(OBJTREE)/xSocksd
 XSOCKS=$(OBJTREE)/xSocks
 XTPROXY=$(OBJTREE)/xTproxy

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ make mingw32 HOST=i686-w64-mingw32
 make mingw32 HOST=x86_64-w64-mingw32
 ```
 
+### Tomatoware
+
+```bash
+# Install Tomatoware on your router from: https://github.com/lancethepants/tomatoware
+git clone https://github.com/lparam/xSocks.git
+make STATIC=1
+
 Usage
 ------------
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Features
 ------------
 * Transparent Proxy for all tcp traffic and udp packet
 * Multithreading
-* Cross-platform, including PC (Linux, [Windows](https://github.com/lparam/xSocks-windows)), Mobile ([Android](https://github.com/lparam/xSocks-android) and Router (OpenWRT)([Tomatoware](https://github.com/lancethepants/tomatoware),[Tomato](http://tomato.groov.pl/?page_id=164))
+* Cross-platform, including PC (Linux, [Windows](https://github.com/lparam/xSocks-windows)), Mobile ([Android](https://github.com/lparam/xSocks-android) and Router (OpenWRT)([Tomatoware](https://github.com/lancethepants/tomatoware))
 
 BUILD
 ------------

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Features
 ------------
 * Transparent Proxy for all tcp traffic and udp packet
 * Multithreading
-* Cross-platform, including PC (Linux, [Windows](https://github.com/lparam/xSocks-windows)), Mobile ([Android](https://github.com/lparam/xSocks-android)) and Router (OpenWRT)
+* Cross-platform, including PC (Linux, [Windows](https://github.com/lparam/xSocks-windows)), Mobile ([Android](https://github.com/lparam/xSocks-android) and Router (OpenWRT)([Tomatoware(https://github.com/lancethepants/tomatoware),[Tomato](http://tomato.groov.pl/?page_id=164))
 
 BUILD
 ------------

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ make mingw32 HOST=x86_64-w64-mingw32
 # Install Tomatoware on your router from: https://github.com/lancethepants/tomatoware
 git clone https://github.com/lparam/xSocks.git
 make STATIC=1
+```
 
 Usage
 ------------

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Features
 ------------
 * Transparent Proxy for all tcp traffic and udp packet
 * Multithreading
-* Cross-platform, including PC (Linux, [Windows](https://github.com/lparam/xSocks-windows)), Mobile ([Android](https://github.com/lparam/xSocks-android) and Router (OpenWRT)([Tomatoware](https://github.com/lancethepants/tomatoware))
+* Cross-platform, including PC (Linux, [Windows](https://github.com/lparam/xSocks-windows)), Mobile ([Android](https://github.com/lparam/xSocks-android) and Router (OpenWRT,[Tomatoware](https://github.com/lancethepants/tomatoware))
 
 BUILD
 ------------

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Features
 ------------
 * Transparent Proxy for all tcp traffic and udp packet
 * Multithreading
-* Cross-platform, including PC (Linux, [Windows](https://github.com/lparam/xSocks-windows)), Mobile ([Android](https://github.com/lparam/xSocks-android) and Router (OpenWRT)([Tomatoware(https://github.com/lancethepants/tomatoware),[Tomato](http://tomato.groov.pl/?page_id=164))
+* Cross-platform, including PC (Linux, [Windows](https://github.com/lparam/xSocks-windows)), Mobile ([Android](https://github.com/lparam/xSocks-android) and Router (OpenWRT)([Tomatoware](https://github.com/lancethepants/tomatoware),[Tomato](http://tomato.groov.pl/?page_id=164))
 
 BUILD
 ------------


### PR DESCRIPTION
Tomato firmware based router can use the way to static compile xSocks after install Tomatoware.

The compiled file run does not depend on tomatoware or any shared libs.